### PR TITLE
Add CRM integration modal

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -3,8 +3,12 @@ import Image from "next/image";
 import TestimonialsAvatars from "./TestimonialsAvatars";
 import config from "@/config";
 import Link from 'next/link';
+import { useState } from 'react';
+import Modal from './Modal';
 
 const Hero = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   return (
     <section className="max-w-7xl mx-auto bg-base-100 flex flex-col lg:flex-row items-center justify-center gap-16 lg:gap-20 px-8 py-8 lg:py-20">
       <div className="flex flex-col gap-10 lg:gap-14 items-center justify-center text-center lg:text-left lg:items-start">
@@ -27,14 +31,13 @@ const Hero = () => {
         </Link>
 
         
-        <Link href="/dashboard">
         <button
           className="btn btn-primary btn-wide"
           style={{ backgroundColor: '#AA80FF' , color: '#fff' }}
+          onClick={() => setIsModalOpen(true)}
         >
           Connect to CRM
         </button>
-        </Link>
         </div>
 
       </div>
@@ -48,6 +51,7 @@ const Hero = () => {
           height={500}
         />
       </div>
+      <Modal isModalOpen={isModalOpen} setIsModalOpen={setIsModalOpen} />
     </section>
   );
 };

--- a/components/Modal.js
+++ b/components/Modal.js
@@ -39,7 +39,7 @@ const Modal = ({ isModalOpen, setIsModalOpen }) => {
               <Dialog.Panel className="relative w-full max-w-3xl h-full overflow-visible transform text-left align-middle shadow-xl transition-all rounded-xl bg-base-100 p-6 md:p-8">
                 <div className="flex justify-between items-center mb-4">
                   <Dialog.Title as="h2" className="font-semibold">
-                    I&apos;m a modal
+                    Integrate Existing CRMs
                   </Dialog.Title>
                   <button
                     className="btn btn-square btn-ghost btn-sm"
@@ -56,7 +56,20 @@ const Modal = ({ isModalOpen, setIsModalOpen }) => {
                   </button>
                 </div>
 
-                <section>And here is my content</section>
+                <section>
+                  <p>Select a CRM to integrate:</p>
+                  <div className="mt-4 space-y-2">
+                    <button className="btn btn-primary btn-block">
+                      Integrate Zoho CRM
+                    </button>
+                    <button className="btn btn-primary btn-block">
+                      Integrate Hubspot
+                    </button>
+                    <button className="btn btn-primary btn-block">
+                      Integrate Salesforce
+                    </button>
+                  </div>
+                </section>
               </Dialog.Panel>
             </Transition.Child>
           </div>


### PR DESCRIPTION
Add a modal dialog box for CRM integration options when clicking 'Connect to CRM'.

* **Hero.js**
  - Import `Modal` component and `useState` from 'react'.
  - Add state variable `isModalOpen` to manage modal visibility.
  - Update 'Connect to CRM' button to set `isModalOpen` to `true` when clicked.
  - Add `Modal` component to JSX, passing `isModalOpen` and `setIsModalOpen` as props.

* **Modal.js**
  - Update modal content to include options for integrating Zoho CRM, Hubspot, and Salesforce.
  - Add buttons for each CRM option within the modal.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DYNAMICMORTAL/smile?shareId=04ae8c41-5f0c-4ca8-80f5-1297e1b04ed5).